### PR TITLE
updates default/app.conf settings to pass Splunk Cloud certification

### DIFF
--- a/default/app.conf
+++ b/default/app.conf
@@ -1,5 +1,5 @@
 [install]
-is_configured = true
+is_configured = false
 state_change_requires_restart = true
 build = 7
 


### PR DESCRIPTION
There is check criteria that default/app.conf setting should be: is_configured = False. 
 

<img width="776" alt="зображення" src="https://user-images.githubusercontent.com/18137839/59428720-b464a500-8de6-11e9-9afc-8b418de11680.png">

Splunk AppInspect checks after fix:

<img width="691" alt="зображення" src="https://user-images.githubusercontent.com/18137839/59431997-f42f8a80-8dee-11e9-9792-59c91fb62143.png">
