### PR TITLE
Update changelog for 1.1.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Changelog
 
 ### 1.1.8
-- Converts api key from unsecured to secured using splunk's storage passwords API
+- Converts api key from unsecured to secured using Splunk's storage passwords API
 - Creating a new input configuration and stream will not save the api key in your input.conf file
-- To migrate your existing app, go to the app's main page, click and edit your linked stream and click Save
-- After you migrate your app, the api key is removed from all your input stanzas in your input.conf file
+- To migrate your existing app and input configurations:
+  - Make sure you have your API ID and key written down or copied to a file **before installation**
+  - Install version 1.1.8 of the app
+  - Restart Splunk
+  - Visit https://\<your splunk address\>/en-US/_bump and click the 'Bump version' button
+  - Your app config will be automatically updated when visiting the inputs page
+    - If you see the error message **Warning! It appears your configuration is incomplete, so you will not be able to create any inputs. Please update your configuration.** when first visiting the page after updating, try refreshing
+    - If that doesn't work, visit the configuration page and ensure your configuration is correct
+  - To update the config for your inputs, visit the Inputs page of the app and click on the name of each of your inputs to edit them, then click the 'Save' button
+  - Your API key will now only be stored using Splunk's storage passowrds API and will no longer be stored in the inputs.conf file
+- When installing this app for the first time, no special action needs to be taken
 
 ### 1.1.4
 - Fix https://github.com/Cisco-AMP/amp4e_splunk_events_input/issues/10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM splunk/splunk:7.2
+FROM splunk/splunk:7.3
 USER root
 RUN apt-get update
 RUN apt-get install -y libxml2-dev libxslt-dev libssl-dev python-cffi libffi-dev openssl netcat
 RUN apt-get install -y python-pip python-dev
 RUN apt-get install -y python-setuptools
+RUN pip install wheel
 RUN pip install setuptools --upgrade
 RUN pip install fabric
 ENV LD_LIBRARY_PATH=${SPLUNK_HOME}/lib:${LD_LIBRARY_PATH}


### PR DESCRIPTION
When testing upgrading from 1.1.7 to 1.1.8, despite bumping the build number in the app.conf file, Splunk was still serving static files from 1.1.7 after upgrading.

This can lead to seeing errors like **Warning! It appears your configuration is incomplete, so you will not be able to create any inputs. Please update your configuration.** and the application not working in general.

To make sure this doesn't happen, I've added instructions that immediately following upgrading the app, user's should use the Splunk _bump endpoint to manually invalidate the JS cache.

There's no issues when installing the app fresh.