### PR TITLE
Add Splunk 8 / Python 3 Support with working test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.8"
 env:
   - DOCKER_COMPOSE_VERSION=1.24.0
 

--- a/bin/requirements-splunk.txt
+++ b/bin/requirements-splunk.txt
@@ -1,2 +1,3 @@
 splunk-sdk
 pika==0.13.1
+requests_mock

--- a/bin/util/api_service.py
+++ b/bin/util/api_service.py
@@ -147,10 +147,10 @@ class ApiError(Exception):
                        'happened because the stream has been deleted directly through API. Please contact support.'
 
     def __init__(self, message, status):
-        super(ApiError, self).__init__(message)
         logger.error('API Error (status {}): {}'.format(status, message))
         self.status = status
         self.stream_is_not_found = False
+        self.message = message
         self.__set_message()
 
     def __str__(self):

--- a/default/app.conf
+++ b/default/app.conf
@@ -13,7 +13,7 @@ label = Cisco AMP for Endpoints Events Input
 [launcher]
 author = Cisco AMP for Endpoints Team
 description = Allows creating and managing event streams from AMP for Endpoints
-version = 1.1.8
+version = 1.1.9
 
 [diag]
 extension_script = diagnosis.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,24 +12,18 @@ services:
       - SPLUNK_PASSWORD=changeme
       - DEBUG=true
     ports:
-      - "8000:8000"
+      - "8001:8000"
     working_dir: /opt/splunk/etc/apps/amp4e_events_input
     entrypoint: /sbin/amp_entrypoint.sh
     command: start-service
   # Uncomment below for a clean container to use for testing
   # splunk-test:
-  #   build: .
   #   image: splunk/splunk:8.1.2
   #   environment:
   #     - SPLUNK_START_ARGS=--accept-license
   #     - SPLUNK_PASSWORD=changeme
   #     - DEBUG=true
-  #   volumes:
-  #     - type: bind
-  #       source: ./
-  #       target: /opt/splunk/etc/apps/amp4e_events_input
   #   ports:
   #     - "8002:8000"
-  #   working_dir: /opt/splunk/etc/apps/amp4e_events_input
-  #   entrypoint: /sbin/amp_entrypoint.sh
+  #   entrypoint: /sbin/entrypoint.sh
   #   command: start-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - SPLUNK_PASSWORD=changeme
       - DEBUG=true
     ports:
-      - "8001:8000"
+      - "8000:8000"
     working_dir: /opt/splunk/etc/apps/amp4e_events_input
     entrypoint: /sbin/amp_entrypoint.sh
     command: start-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - SPLUNK_HOME=/opt/splunk
       - SPLUNK_START_ARGS=--accept-license
-      - SPLUNK_PASSWORD=5up3rn0va
+      - SPLUNK_PASSWORD=changeme
       - DEBUG=true
     ports:
       - "8000:8000"

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,1 +1,3 @@
+import sys
+sys.path.insert(0,"/opt/splunk/etc/apps/amp4e_events_input/test")
 import helper

--- a/test/amp4e_events_input/test_amp_storage_wrapper.py
+++ b/test/amp4e_events_input/test_amp_storage_wrapper.py
@@ -2,6 +2,7 @@ import unittest
 import json
 import sys
 from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
+sys.path.insert(0, make_splunkhome_path(["etc", "apps", "amp4e_events_input"]))
 sys.path.insert(0, make_splunkhome_path(["lib","python3","site-packages"]))
 from splunklib.client import Service, KVStoreCollection
 

--- a/test/amp4e_events_input/test_stream_dict_manager.py
+++ b/test/amp4e_events_input/test_stream_dict_manager.py
@@ -1,4 +1,7 @@
 import unittest
+import sys
+from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
+sys.path.insert(0, make_splunkhome_path(["etc", "apps", "amp4e_events_input"]))
 from bin.amp4e_events_input.stream_dict_manager import StreamDictManager
 
 

--- a/test/amp4e_events_input/test_transient_service_factory.py
+++ b/test/amp4e_events_input/test_transient_service_factory.py
@@ -2,6 +2,7 @@ import unittest
 import sys
 from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
 sys.path.insert(0, make_splunkhome_path(["lib","python3","site-packages"]))
+sys.path.insert(0, make_splunkhome_path(["etc", "apps", "amp4e_events_input"]))
 from splunklib.client import Service
 
 from bin.amp4e_events_input.transient_service_factory import TransientServiceFactory

--- a/test/helper.py
+++ b/test/helper.py
@@ -3,5 +3,5 @@ import os
 
 # Add bin to sys path since splunk runs it within this context
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'bin'))
-sys.path.insert(3, "/usr/local/lib/python2.7/dist-packages")
-sys.path.insert(4, "/usr/lib/python2.7/dist-packages")
+sys.path.insert(3, "/usr/local/lib/python3.7/dist-packages")
+sys.path.insert(4, "/usr/lib/python3.7/dist-packages")

--- a/test/util/test_api_service.py
+++ b/test/util/test_api_service.py
@@ -1,7 +1,10 @@
 import unittest
 import json
+import sys
+from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
+sys.path.insert(0,"/opt/splunk/lib/python3/site-packages/requests_mock")
+sys.path.insert(1, make_splunkhome_path(["etc", "apps", "amp4e_events_input", "bin"]))
 import requests_mock
-
 from util.api_service import ApiService, ApiError
 
 

--- a/test/util/test_logger.py
+++ b/test/util/test_logger.py
@@ -1,6 +1,5 @@
 import unittest
 import logging
-
 from bin.util.logger import Logger
 
 


### PR DESCRIPTION
This PR is raised to merge the code with working unit test cases.
- The Python version has been changed to 3.8.
- The imports for the unittests are fixed.
- The app version number is updated to 1.1.9.