### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM splunk/splunk:8.1.2-debian
 USER root
 RUN apt-get update
 RUN apt-get install -y libxml2-dev libxslt-dev libssl-dev python3-cffi libffi-dev openssl netcat
-RUN apt-get install -y python3-pip python3-dev python3-requests
-RUN apt-get install -y python3-setuptools
+RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install fabric
 RUN python3 -m pip uninstall enum
 ENV LD_LIBRARY_PATH=${SPLUNK_HOME}/lib:${LD_LIBRARY_PATH}


### PR DESCRIPTION
* removes extraneous python packages as it interferes with the existing python installation from the Splunk container
* Upgrades pip to fix  #68, pip relies on cryptography which recently switched to Rust from C - we don't have Rust installed in the container (nor do we want to). Newer versions of pip have everything ready to go so we don't need to install Rust. 