### PR TITLE
Fix creating and editing inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 2.0.2
+- Fixed an issue where creating or editing an input would fail in some cases
+
+### 2.0.1
+- Adds Splunk 8 and Python 3 support
+
 ### 1.1.8
 - Converts api key from unsecured to secured using Splunk's storage passwords API
 - Creating a new input configuration and stream will not save the api key in your input.conf file

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If a **new folder is added at the top level of the app**, it's name must be adde
 Creates a package for release on Splunkbase.
 
 ```bash
-docker-compose exec splunk python3 /usr/local/bin/fab splunkbase-release
+docker-compose exec splunk python3 /usr/bin/fab splunkbase-release
 ```
 
 ## Known Issues

--- a/appserver/static/js/views/Amp4eEventsInputCreateView.js
+++ b/appserver/static/js/views/Amp4eEventsInputCreateView.js
@@ -144,7 +144,7 @@ define([
 
         setInputAndProceed: function(){
             $.ajax({
-                url: splunkd_utils.fullpath('/servicesNS/admin/amp4e_events_input/data/inputs/amp4e_events_input'),
+                url: splunkd_utils.fullpath('/servicesNS/nobody/amp4e_events_input/data/inputs/amp4e_events_input'),
                 data: { output_mode: 'json' },
                 type: 'GET',
                 success: function(resp) {
@@ -195,7 +195,7 @@ define([
         // this will only get called if saveWithAPI succeeds
         saveInput: function() {
             $.ajax({
-                url: splunkd_utils.fullpath(['/servicesNS/admin/amp4e_events_input/data/inputs/amp4e_events_input', encodeURIComponent(this.getInputName())].join('/')),
+                url: splunkd_utils.fullpath(['/servicesNS/nobody/amp4e_events_input/data/inputs/amp4e_events_input', encodeURIComponent(this.getInputName())].join('/')),
                 data: this.isUpdatePage ? this.getStreamUpdateOptions(false) : this.getStreamOptions(false),
                 type: 'POST',
                 success: function(resp) {
@@ -250,7 +250,7 @@ define([
 
             // migrate to new secure format for api key if an api key exists in unsecure format
             // to blank out api key, we must set it to null
-            if (this.ampInput) {
+            if (this?.ampInput?.content?.api_key) {
               apiKey = this.ampInput.content.api_key;
               if (apiKey.length > 0 && includeAPIKey == false) {
                   return {

--- a/default/app.conf
+++ b/default/app.conf
@@ -1,7 +1,7 @@
 [install]
 is_configured = false
 state_change_requires_restart = true
-build = 11
+build = 12
 
 [package]
 id = amp4e_events_input
@@ -13,7 +13,7 @@ label = Cisco AMP for Endpoints Events Input
 [launcher]
 author = Cisco AMP for Endpoints Team
 description = Allows creating and managing event streams from AMP for Endpoints
-version = 2.0.1
+version = 2.0.2
 
 [diag]
 extension_script = diagnosis.py


### PR DESCRIPTION
Input creation was failing when there was no user named `admin` on the Splunk instance. This changes the owner of the input to `nobody`. 

Should (hopefully) fix #67 #48 #30

Additionally, adds safe navigation operators to the API key check to fix JS failures when attempting to edit inputs.

PR check to run tests is on the fritz, here's the result of running them locally:

```
~/repos/amp4e_splunk_events_input  develop ✗                                                                                    3m ⚑  
▶ docker-compose exec splunk sh -c '$SPLUNK_HOME/bin/splunk cmd python -m unittest discover' 
........................................
----------------------------------------------------------------------
Ran 40 tests in 3.835s

OK
```